### PR TITLE
[Proposal]: Consolidate and simplify the generation of codes.

### DIFF
--- a/gauth/gauth.go
+++ b/gauth/gauth.go
@@ -3,12 +3,9 @@
 package gauth
 
 import (
-	"crypto/hmac"
-	"crypto/sha1"
-	"encoding/base32"
-	"fmt"
-	"math/big"
 	"time"
+
+	"bitbucket.org/creachadair/otp"
 )
 
 // IndexNow returns the current 30-second time slice index, and the number of
@@ -18,31 +15,16 @@ func IndexNow() (int64, int) {
 	return time / 30, int(time % 30)
 }
 
-// Code returns the OTP code for the given secret at the specified time slice
-// index. It will report an error if the secret is not valid Base32 or if HMAC
-// generation fails.
-func Code(sec string, ts int64) (string, error) {
-	key, err := base32.StdEncoding.DecodeString(sec)
-	if err != nil {
-		return "", err
+// Codes returns the OTP codes for the given secret at the specified time slice
+// and one slice on either side of it. It will report an error if the secret is
+// not valid Base32.
+func Codes(sec string, ts int64) (prev, curr, next string, _ error) {
+	var cfg otp.Config
+	if err := cfg.ParseKey(sec); err != nil {
+		return "", "", "", err
 	}
-	enc := hmac.New(sha1.New, key)
-	msg := make([]byte, 8)
-	msg[0] = (byte)(ts >> (7 * 8) & 0xff)
-	msg[1] = (byte)(ts >> (6 * 8) & 0xff)
-	msg[2] = (byte)(ts >> (5 * 8) & 0xff)
-	msg[3] = (byte)(ts >> (4 * 8) & 0xff)
-	msg[4] = (byte)(ts >> (3 * 8) & 0xff)
-	msg[5] = (byte)(ts >> (2 * 8) & 0xff)
-	msg[6] = (byte)(ts >> (1 * 8) & 0xff)
-	msg[7] = (byte)(ts >> (0 * 8) & 0xff)
-	if _, err := enc.Write(msg); err != nil {
-		return "", err
-	}
-	hash := enc.Sum(nil)
-	offset := hash[19] & 0x0f
-	trunc := hash[offset : offset+4]
-	trunc[0] &= 0x7F
-	res := new(big.Int).Mod(new(big.Int).SetBytes(trunc), big.NewInt(1000000))
-	return fmt.Sprintf("%06d", res), nil
+	prev = cfg.HOTP(uint64(ts - 1))
+	curr = cfg.HOTP(uint64(ts))
+	next = cfg.HOTP(uint64(ts + 1))
+	return
 }

--- a/gauth/gauth_test.go
+++ b/gauth/gauth_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/pcarrier/gauth/gauth"
 )
 
-func TestCode(t *testing.T) {
+func TestCodes(t *testing.T) {
 	tests := []struct {
 		secret string
 		index  int64
@@ -20,7 +20,7 @@ func TestCode(t *testing.T) {
 		{"blargh!", 123, "", true},
 	}
 	for _, test := range tests {
-		got, err := gauth.Code(test.secret, test.index)
+		_, got, _, err := gauth.Codes(test.secret, test.index)
 		if err != nil && !test.fail {
 			t.Errorf("Code(%q, %d): unexpected error: %v", test.secret, test.index, err)
 		} else if got != test.want {

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/pcarrier/gauth
 go 1.12
 
 require (
+	bitbucket.org/creachadair/otp v0.0.2
 	golang.org/x/crypto v0.0.0-20190530122614-20be4c3c3ed5
 	golang.org/x/sys v0.0.0-20190531175056-4c3a928424d2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+bitbucket.org/creachadair/otp v0.0.2 h1:0IAI6yUiapmEHt/x6sdmv8BnPRVOyWT/mPxqYkcYbF8=
+bitbucket.org/creachadair/otp v0.0.2/go.mod h1:1RXxCIhHl/bxTZlSWONJzpCOi5uHZuwrDAkomlYrUGg=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190530122614-20be4c3c3ed5 h1:8dUaAV7K4uHsF56JQWkprecIQKdPHtR9jCHF5nB8uzc=
 golang.org/x/crypto v0.0.0-20190530122614-20be4c3c3ed5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=


### PR DESCRIPTION
This PR does not change the functionality of the tool, but proposes a larger change to the internals. With this PR, the implementation now uses the https://godoc.org/bitbucket.org/creachadair/otp package which makes the code here shorter (and subsumes normalizeSecret). That library package is one I maintain, but I certainly understand if you'd prefer to avoid an external dependency.

Other than that, the main change here is to rework `gauth.Code` as `gauth.Codes`, which returns all three (previous, current, and next) code strings needed by the CLI in one step. In doing so it also obsoletes `authCodeOrDie`, since there is now only one decode step to check.

