### PR TITLE
Fix incorrect example input in the README file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Usage
 
         AWS:   ABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVWXYZ234567
         Airbnb:abcd efgh ijkl mnop
-        Google:a2b3c4d5e6f7g8h9
+        Google:a2b3c4d5e6f7ghij
         Github:234567qrstuvwxyz
 
 - Restrict access to your user:


### PR DESCRIPTION
The "Google" example code used invalid base-32 characters ("8" and "9") and
thus generated errors when decoding the keys.