### PR TITLE
Update build status badge.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Build Status](https://github.com/pcarrier/gauth/workflows/Go%20presubmit/badge.svg)
+[![Go presubmit](https://github.com/pcarrier/gauth/workflows/Go%20presubmit/badge.svg)](https://github.com/pcarrier/gauth/actions)
 
 gauth: replace Google Authenticator
 ===================================

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/pcarrier/gauth.png?branch=main)](https://travis-ci.org/pcarrier/gauth)
+![Build Status](https://github.com/pcarrier/gauth/workflows/Go%20presubmit/badge.svg)
 
 gauth: replace Google Authenticator
 ===================================


### PR DESCRIPTION
Since the CI build is now on GitHub actions rather than Travis, point to the
Actions badge image instead.