### PR TITLE
Update Go versions in CI.

### DIFF
--- a/.github/workflows/go-presubmit.yml
+++ b/.github/workflows/go-presubmit.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ['1.11', '1.12', '1.13', '1.14', '1.15']
+        go-version: ['1.13', '1.14', '1.15', '1.16', '1.17']
     steps:
     - name: Install Go ${{ matrix.go-version }}
       uses: actions/setup-go@v1


### PR DESCRIPTION
Include Go 1.16 and 1.17, drop 1.11 and 1.12.