### PR TITLE
Fix CI configuration.

### DIFF
--- a/.github/workflows/go-presubmit.yml
+++ b/.github/workflows/go-presubmit.yml
@@ -13,13 +13,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ['1.13', '1.14', '1.15', '1.16', '1.17']
+        go-version: ['1.13', '1.14', '1.15', '1.16', '1.17', '1.18']
     steps:
     - name: Install Go ${{ matrix.go-version }}
       uses: actions/setup-go@v1
       with:
         go-version: ${{ matrix.go-version }}
     - uses: actions/checkout@v2
-    - uses: creachadair/go-presubmit-action@default
+    - uses: creachadair/go-presubmit-action@v1
       with:
         staticcheck-version: "2020.1.6"


### PR DESCRIPTION
- Update to use the tagged version v1 of the workflow.
- Add Go 1.18 to the test matrix.