### PR TITLE
use filepath to join the path to the csv file

### DIFF
--- a/gauth.go
+++ b/gauth.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"os"
 	"os/user"
-	"path"
+	"path/filepath"
 	"strings"
 	"syscall"
 	"text/tabwriter"
@@ -21,7 +21,7 @@ func main() {
 		if err != nil {
 			log.Fatal(err)
 		}
-		cfgPath = path.Join(user.HomeDir, ".config/gauth.csv")
+		cfgPath = filepath.Join(user.HomeDir, ".config", "gauth.csv")
 	}
 
 	cfgContent, err := gauth.LoadConfigFile(cfgPath, getPassword)


### PR DESCRIPTION
this ensures `\` on the path on windows