### PR TITLE
Features: Adding keys, removing keys and printing secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ Usage
         $ gauth Google -b
         477615
 
+- Run `gauth KEYNAME -s` to retrieve an accounts secret from the config.
+
+        $ gauth Google -s
+        your_secret_for_google
+
 - `gauth` is convenient to use in `watch`.
 
         $ watch -n1 gauth
@@ -52,6 +57,22 @@ Usage
 - If you find yourself needing to interpret a QR code (e.g. exporting a code
   from an existing Google Authenticator setup, on a phone to which you do not
   have root access), then [gauthQR](https://github.com/jbert/gauthQR) may be useful.
+
+
+Adding and removing keys
+------------------------
+
+- Run `gauth KEYNAME -a` to add a new key.
+
+        $ gauth Google -a
+        Key for Google: examplekey
+        Current OTP for Google: 306726
+
+- Run `gauth KEYNAME -r` to remove an existing key.
+
+        $ gauth Google -r
+        Are you sure you want to remove Google [y/N]: y
+        Google has been removed.
 
 Encryption
 ----------

--- a/gauth.go
+++ b/gauth.go
@@ -18,24 +18,45 @@ import (
 
 func main() {
 	accountName := ""
-	isBareCode := false
+	argument := ""
 
 	if len(os.Args) > 1 {
 		accountName = os.Args[1]
 	}
+
 	if len(os.Args) > 2 {
 		if os.Args[2] == "-b" || os.Args[2] == "-bare" {
-			isBareCode = true
+			argument = "bare"
+		} else if os.Args[2] == "-a" || os.Args[2] == "-add" {
+			argument = "add"
+		} else if os.Args[2] == "-r" || os.Args[2] == "-remove" {
+			argument = "remove"
+		} else if os.Args[2] == "-s" || os.Args[2] == "-secret" {
+			argument = "secret"
 		}
 	}
 
-	urls := getUrls()
-
-	if isBareCode && accountName != "" {
-		printBareCode(accountName, urls)
-	} else {
-		printAllCodes(urls)
+	if accountName != "" {
+		switch argument {
+		case "bare":
+			printBareCode(accountName, getUrls())
+			return
+		case "add":
+			addCode(accountName)
+			return
+		case "remove":
+			removeCode(accountName)
+			return
+		case "secret":
+			printSecret(accountName, getUrls())
+			return
+		default:
+			printAllCodes(getUrls())
+			return
+		}
 	}
+
+	printAllCodes(getUrls())
 }
 
 func getPassword() ([]byte, error) {

--- a/gauth.go
+++ b/gauth.go
@@ -207,6 +207,16 @@ func removeCode(accountName string) {
 
 	fmt.Printf("%s has been removed.", accountName)
 }
+
+func printSecret(accountName string, urls []*otpauth.URL) {
+	for _, url := range urls {
+		if strings.EqualFold(strings.ToLower(accountName), strings.ToLower(url.Account)) {
+			fmt.Print(url.RawSecret)
+			break
+		}
+	}
+}
+
 func printAllCodes(urls []*otpauth.URL) {
 	_, progress := gauth.IndexNow() // TODO: do this per-code
 

--- a/gauth.go
+++ b/gauth.go
@@ -210,7 +210,7 @@ func removeCode(accountName string) {
 	}
 
 	// Prompt for confirmation
-	fmt.Printf("Are you sure you want to remove \"%s\" [y/N]: ", accountName)
+	fmt.Printf("Are you sure you want to remove %s [y/N]: ", accountName)
 	reader := bufio.NewReader(os.Stdin)
 	confirmation, _ := reader.ReadString('\n')
 

--- a/gauth.go
+++ b/gauth.go
@@ -43,7 +43,7 @@ func getPassword() ([]byte, error) {
 	return term.ReadPassword(int(syscall.Stdin))
 }
 
-func getUrls() []*otpauth.URL {
+func getConfigPath() string {
 	cfgPath := os.Getenv("GAUTH_CONFIG")
 	if cfgPath == "" {
 		user, err := user.Current()
@@ -52,6 +52,12 @@ func getUrls() []*otpauth.URL {
 		}
 		cfgPath = filepath.Join(user.HomeDir, ".config", "gauth.csv")
 	}
+
+	return cfgPath
+}
+
+func getUrls() []*otpauth.URL {
+	cfgPath := getConfigPath()
 
 	cfgContent, err := gauth.LoadConfigFile(cfgPath, getPassword)
 	if err != nil {

--- a/gauth.go
+++ b/gauth.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"fmt"
 	"log"
 	"os"


### PR DESCRIPTION
Hiya! This PR adds the 3 new command line arguments listed below (this resolves #51). It also includes a bit of refactoring, especially for the main function due to the increased number of possible command line arguments.

The README has been updated to reflect these new arguments

### Adding keys
Keys can now be added to the config file (encrypted or not) with `gauth KEYNAME -a` or `gauth KEYNAME -add`. If the config file is encrypted, the user will be prompted for the password before being prompted for the new account's secret. Once the account has been added, the current OTP will be printed for verification purposes

### Removing keys
Keys can be removed from the config file (encrypted or not) with `gauth KEYNAME -r` or `gauth KEYNAME -remove`. The user is prompted for a password if needed and asked to confirm the removal just in case.

### Printing secrets
An account's secret can be retrieved from the config with `gauth KEYNAME -s` or `gauth KEYNAME -secret`.

\-

Best,
Erica :orange_heart: 